### PR TITLE
Use ghc as the linker with hsc2hs

### DIFF
--- a/Cabal/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/Distribution/Simple/Program/GHC.hs
@@ -16,6 +16,7 @@ module Distribution.Simple.Program.GHC (
 
     runGHC,
 
+    packageDbArgs,
     packageDbArgsDb,
     normaliseGhcArgs
 


### PR DESCRIPTION
 Use ghc as the linker with hsc2hs

This enables hsc2hs to depend on Haskell code via foreign export. I have
an upcoming use case that requires this.

Should we make this optional? I'm hoping we can get away without adding
an option, because it shouldn't break any existing uses: using GHC as
the linker only provides access to more symbols, which shouldn't break
anything provided the libraries that GHC adds don't shadow anything,
which should be the case.

---
Please include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [X] Any changes that could be relevant to users have been recorded in the changelog.
* [X] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
